### PR TITLE
Update bedrock assets download

### DIFF
--- a/src/Alex/ResourceManager.cs
+++ b/src/Alex/ResourceManager.cs
@@ -419,7 +419,21 @@ namespace Alex
 				{
 					using (ZipArchive zipArchive = new ZipArchive(Storage.OpenFileStream(bedrockPath, FileMode.Open)))
 					{
-						zipArchive.ExtractToDirectory(di.FullName);
+						var root = "bedrock-samples-main/resource_pack/";
+						var resourcePackFiles = from currentEntry in zipArchive.Entries
+												where currentEntry.FullName.StartsWith(root)
+												where !String.IsNullOrWhiteSpace(currentEntry.Name)
+												select currentEntry;
+
+						foreach (ZipArchiveEntry entry in resourcePackFiles)
+						{
+							var path = Path.Combine(di.FullName, entry.FullName.Substring(root.Length));
+							if (!Directory.Exists(path))
+							{
+								Storage.TryCreateDirectory(Path.GetDirectoryName(path));
+							}
+							entry.ExtractToFile(path);
+						}
 					}
 
 					Storage.Delete(bedrockPath);

--- a/src/Alex/Utils/Assets/MCBedrockAssetUtils.cs
+++ b/src/Alex/Utils/Assets/MCBedrockAssetUtils.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
+using System.Text.Json;
 using System.Threading;
 using Alex.Common;
 using Alex.Common.Services;
@@ -16,11 +18,9 @@ namespace Alex.Utils.Assets
 	{
 		private static readonly Logger Log = LogManager.GetCurrentClassLogger(typeof(MCBedrockAssetUtils));
 
-		private const string DownloadURL = "https://aka.ms/resourcepacktemplate";
+		private const string VersionURL = "https://raw.githubusercontent.com/Mojang/bedrock-samples/main/version.json";
+		private const string DownloadURL = "https://codeload.github.com/Mojang/bedrock-samples/zip/refs/heads/main";
 		private static readonly string CurrentBedrockVersionStorageKey = Path.Combine("assets", "bedrock-version.txt");
-
-		private static readonly Regex ExtractVersionFromFilename = new Regex(
-			@"Vanilla_.*Pack_(?<version>[\d\.]+).zip", RegexOptions.Compiled);
 
 		private IStorageSystem Storage { get; }
 
@@ -67,71 +67,63 @@ namespace Alex.Utils.Assets
 
 				try
 				{
-					var zipDownloadHeaders = httpClient.Send(
-						new HttpRequestMessage(HttpMethod.Get, DownloadURL), HttpCompletionOption.ResponseHeadersRead);
+					var versionRequest = httpClient.Send(new HttpRequestMessage(HttpMethod.Get, VersionURL), HttpCompletionOption.ResponseContentRead);
+					var versionStream = versionRequest.Content.ReadAsStreamAsync().Result;
 
-					var fileName = zipDownloadHeaders.Content?.Headers?.ContentDisposition?.FileName
-					               ?? zipDownloadHeaders.RequestMessage?.RequestUri?.LocalPath;
+					var latestVersion = JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, string>>>(versionStream)["latest"]["version"];
 
-					var versionMatch = ExtractVersionFromFilename.Match(fileName);
-
-					if (versionMatch.Success)
+					if (latestVersion != currentVersion)
 					{
-						var latestVersion = versionMatch.Groups["version"].Value;
+						if (Storage.Exists(path))
+							Storage.Delete(path);
 
-						if (latestVersion != currentVersion)
+						progressReceiver?.UpdateProgress(
+							0, "Downloading latest bedrock assets...", "This could take a while...");
+
+						Stopwatch sw = new Stopwatch();
+
+						using (HttpClient c = new HttpClient())
 						{
-							if (Storage.Exists(path))
-								Storage.Delete(path);
-
-							progressReceiver?.UpdateProgress(
-								0, "Downloading latest bedrock assets...", "This could take a while...");
-
-							Stopwatch sw = new Stopwatch();
-
-							using (HttpClient c = new HttpClient())
-							{
-								string archivePath = string.Empty;
-								
-								var downloadTask = c.DownloadDataAsync(zipDownloadHeaders.RequestMessage.RequestUri, (p) =>
-								{
-									var downloadSpeed =
-										$"Download speed: {FormattingUtils.GetBytesReadable((long)(Convert.ToDouble(p.BytesReceived) / sw.Elapsed.TotalSeconds), 2)}/s";
-
-									var totalSize = p.TotalBytesToReceive ?? 1;
-									var progressPercentage = (int)Math.Ceiling((100d / totalSize) * p.BytesReceived);
-									
-									progressReceiver?.UpdateProgress(
-										progressPercentage, $"Downloading latest bedrock assets...", downloadSpeed);
-									
-								}, CancellationToken.None).ContinueWith(
-									r =>
-									{
-										if (r.IsFaulted)
-										{
-											Log.Error(r.Exception, "Failed to download bedrock assets...");
-											return;
-										}
-
-										var content = r.Result;
-
-										archivePath = Path.Combine("assets", $"bedrock-{latestVersion}.zip");
-
-										// save locally
-
-										Storage.TryWriteString(CurrentBedrockVersionStorageKey, latestVersion);
-
-										Storage.TryWriteBytes(archivePath, content);
-									});
-								
-								sw.Restart();
-								
-								SpinWait.SpinUntil(() => downloadTask.IsCompleted);
-								path = archivePath;
-							}
+							string archivePath = string.Empty;
 							
-							return true;
+							var downloadTask = c.DownloadDataAsync(new Uri(DownloadURL), (p) =>
+							{
+								var downloadSpeed =
+									$"Download speed: {FormattingUtils.GetBytesReadable((long)(Convert.ToDouble(p.BytesReceived) / sw.Elapsed.TotalSeconds), 2)}/s";
+
+								var totalSize = p.TotalBytesToReceive ?? 1;
+								var progressPercentage = (int)Math.Ceiling((100d / totalSize) * p.BytesReceived);
+								
+								progressReceiver?.UpdateProgress(
+									progressPercentage, $"Downloading latest bedrock assets...", downloadSpeed);
+								
+							}, CancellationToken.None).ContinueWith(
+								r =>
+								{
+									if (r.IsFaulted)
+									{
+										Log.Error(r.Exception, "Failed to download bedrock assets...");
+										return;
+									}
+
+									var content = r.Result;
+
+									archivePath = Path.Combine("assets", $"bedrock-{latestVersion}.zip");
+
+									// save locally
+
+									Storage.TryWriteString(CurrentBedrockVersionStorageKey, latestVersion);
+
+									Storage.TryWriteBytes(archivePath, content);
+								});
+							
+							sw.Restart();
+							
+							SpinWait.SpinUntil(() => downloadTask.IsCompleted);
+							path = archivePath;
 						}
+
+						return true;
 					}
 
 					return false;


### PR DESCRIPTION
`https://aka.ms/resourcepacktemplate` no longer gives the Vanilla resource pack. Instead, it redirects to https://github.com/Mojang/bedrock-samples