### PR TITLE
Change GitHub Raw to JsDelivr

### DIFF
--- a/src/Alex/Utils/Assets/MCBedrockAssetUtils.cs
+++ b/src/Alex/Utils/Assets/MCBedrockAssetUtils.cs
@@ -18,7 +18,7 @@ namespace Alex.Utils.Assets
 	{
 		private static readonly Logger Log = LogManager.GetCurrentClassLogger(typeof(MCBedrockAssetUtils));
 
-		private const string VersionURL = "https://raw.githubusercontent.com/Mojang/bedrock-samples/main/version.json";
+		private const string VersionURL = "https://cdn.jsdelivr.net/gh/Mojang/bedrock-samples@main/version.json";
 		private const string DownloadURL = "https://codeload.github.com/Mojang/bedrock-samples/zip/refs/heads/main";
 		private static readonly string CurrentBedrockVersionStorageKey = Path.Combine("assets", "bedrock-version.txt");
 


### PR DESCRIPTION
解决GitHub Raw在中国不可用的问题

Google Translate:
to solve the problem that Github Raw is not available in China